### PR TITLE
Bug fix: added custom redirect status code

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,5 +1,5 @@
-/github             https://github.com/raiyansarker
-/facebook           https://facebook.com/raiyansarker.akib
-/instagram          https://instagram.com/raiyan_sarker_
-/twitter            https://twitter.com/raiyan_sarker_
-/blog            https://blog.raiyansarker.com
+/github             https://github.com/raiyansarker           302
+/facebook           https://facebook.com/raiyansarker.akib    302
+/instagram          https://instagram.com/raiyan_sarker_      302
+/twitter            https://twitter.com/raiyan_sarker_        302
+/blog            https://blog.raiyansarker.com                302


### PR DESCRIPTION
By default, Netlify sets 301 status which is permeant redirect. So the links that are being set can't be edited in future.

So now the status code is 302 which is temporary and can be edited in future!